### PR TITLE
fix: remove redundant await in transactions service

### DIFF
--- a/src/modules/transactions/services/transactions.service.ts
+++ b/src/modules/transactions/services/transactions.service.ts
@@ -20,7 +20,7 @@ export class TransactionsService {
     private readonly transactionsRepo: TransactionsRepository,
     private readonly validateBankAccountOwnershipService: ValidateBankAccountOwnershipService,
     private readonly validateCategoryOwnershipService: ValidateCategoryOwnershipService,
-    private readonly validateTransactionOwnsershipService: ValidateTransactionOwnershipService,
+    private readonly validateTransactionOwnershipService: ValidateTransactionOwnershipService,
   ) {}
 
   async create(userId: string, createTransactionDto: CreateTransactionDto) {
@@ -106,9 +106,9 @@ export class TransactionsService {
     categoryId,
     transactionId,
   }: ValidateEntitiesOwnershipInterface) {
-    await await Promise.all([
+    await Promise.all([
       transactionId &&
-        this.validateTransactionOwnsershipService.validate(
+        this.validateTransactionOwnershipService.validate(
           userId,
           transactionId,
         ),


### PR DESCRIPTION
## Summary
- refactor: rename transaction ownership service property
- fix: remove redundant await in ownership validation

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68921b5e788883289f671b12d40128c5